### PR TITLE
fix instance_std nan issue

### DIFF
--- a/evonorm2d.py
+++ b/evonorm2d.py
@@ -3,6 +3,8 @@ import torch.nn as nn
 
 def instance_std(x, eps=1e-5):
     var = torch.var(x, dim = (2, 3), keepdim=True).expand_as(x)
+    if torch.isnan(var).any():
+        var = torch.zeros(var.shape)
     return torch.sqrt(var + eps)
 
 def group_std(x, groups = 32, eps = 1e-5):


### PR DESCRIPTION
`torch.var(x)` returns NaN when x is a scaler. In the event that width=channel=1, instance_std will return NaN and `torch.max([a,NaN])` returns NaN. To solve this, I check in `instance_std` if `torch.var()` returns any NaN and if so, set `var=0`